### PR TITLE
✨ 일기 관련 api 구현

### DIFF
--- a/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
+++ b/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 
 @Api(tags = "일기 API")
@@ -31,6 +33,13 @@ public class DiaryController {
     @GetMapping(value = "/{id}")
     public ResponseDto<DiaryResponse> getOneDiary(@PathVariable Long id, HttpServletRequest servletRequest) {
         return ResponseDto.ok(diaryService.getOneDiary(id, (Long)servletRequest.getAttribute("USER_ID")));
+    }
+
+    @Operation(summary = "월단위 일기 조회", description = "구간에 해당하는 이미지 List 보여주기")
+    @GetMapping(value = "/monthly")
+    public ResponseDto<?> getImageListForMonth(HttpServletRequest servletRequest, @RequestParam("startDate") String startDate, @RequestParam("endDate") String endDate){
+        List<Map<String, String>> diaryMap = diaryService.getImageListByDateRange(startDate, endDate, (Long)servletRequest.getAttribute("USER_ID"));
+        return ResponseDto.ok(diaryMap);
     }
 ////
 ////    @Operation(summary = "이미지 선택", description = "4개의 이미지 중 사용자가 선택한 이미지만 남기기")
@@ -54,12 +63,6 @@ public class DiaryController {
 ////                    .body(imageData);
 ////    }
 ////
-////    @Operation(summary = "이미지 해당 달 조회", description = "현재 달에 해당하는 이미지 List 보여주기")
-////    @GetMapping(value = "/imageMonth")
-////    public ResponseEntity<?> getImageListForMonth() throws IOException {
-////        List<Map<Integer, DiaryResponse>> diaryMap = diaryService.getImageListByMonth();
-////        return ResponseEntity.ok().body(diaryMap);
-////    }
 ////
 ////    @Operation(summary = "해당 주 감정 점수 조회", description = "현재 주에 해당하는 감정 점수 보여주기")
 ////    @GetMapping(value = "/scoreWeek")

--- a/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
+++ b/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
@@ -1,6 +1,7 @@
 package com.grimpan.emodiary.controller;
 
 import com.grimpan.emodiary.dto.request.DiaryWriteRequest;
+import com.grimpan.emodiary.dto.response.DiaryResponse;
 import com.grimpan.emodiary.dto.response.DiaryWriteResponse;
 import com.grimpan.emodiary.dto.response.ResponseDto;
 import com.grimpan.emodiary.service.DiaryService;
@@ -11,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.util.Map;
 
 
 @Api(tags = "일기 API")
@@ -26,13 +26,12 @@ public class DiaryController {
     public ResponseDto<DiaryWriteResponse> createDiary(HttpServletRequest servletRequest, @RequestBody DiaryWriteRequest request) throws IOException {
         return ResponseDto.ok(diaryService.create(request, (Long)servletRequest.getAttribute("USER_ID")));
     }
-////
-////    @Operation(summary = "일기 상세 조회", description = "id로 일기 상세 조회")
-////    @GetMapping(value = "/{id}")
-////    public ResponseEntity<DiaryResponse> getOneDiary(@PathVariable Long id) {
-////        DiaryResponse response = diaryService.getOneDiary(id);
-////        return ResponseEntity.ok().body(response);
-////    }
+
+    @Operation(summary = "일기 상세 조회", description = "id로 일기 상세 조회")
+    @GetMapping(value = "/{id}")
+    public ResponseDto<DiaryResponse> getOneDiary(@PathVariable Long id, HttpServletRequest servletRequest) {
+        return ResponseDto.ok(diaryService.getOneDiary(id, (Long)servletRequest.getAttribute("USER_ID")));
+    }
 ////
 ////    @Operation(summary = "이미지 선택", description = "4개의 이미지 중 사용자가 선택한 이미지만 남기기")
 ////    @PutMapping(value = "/{id}/images")

--- a/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
+++ b/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
@@ -1,8 +1,17 @@
 package com.grimpan.emodiary.controller;
 
+import com.grimpan.emodiary.dto.request.DiaryWriteRequest;
+import com.grimpan.emodiary.dto.response.DiaryWriteResponse;
+import com.grimpan.emodiary.dto.response.ResponseDto;
+import com.grimpan.emodiary.service.DiaryService;
 import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.Map;
 
 
 @Api(tags = "일기 API")
@@ -10,55 +19,53 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/diary")
 public class DiaryController {
-//    private final DiaryService diaryService;
-//
-//    @Operation(summary = "일기 작성", description = "작성 후 reponse로 그림 4개 return")
-//    @PostMapping("")
-//    public ResponseEntity<DiaryWriteResponse> createDiary(@RequestBody DiaryWriteRequest request) throws IOException {
-//        DiaryWriteResponse response = diaryService.create(request);
-//        return ResponseEntity.ok()
-//                .body(response);
-//    }
-//
-//    @Operation(summary = "일기 상세 조회", description = "id로 일기 상세 조회")
-//    @GetMapping(value = "/{id}")
-//    public ResponseEntity<DiaryResponse> getOneDiary(@PathVariable Long id) {
-//        DiaryResponse response = diaryService.getOneDiary(id);
-//        return ResponseEntity.ok().body(response);
-//    }
-//
-//    @Operation(summary = "이미지 선택", description = "4개의 이미지 중 사용자가 선택한 이미지만 남기기")
-//    @PutMapping(value = "/{id}/images")
-//    public ResponseEntity<DiaryResponse> chooseImage(@PathVariable Long id, @RequestBody List<ImageChooseRequest> requestList) throws IOException {
-//        DiaryResponse response = diaryService.chooseImage(id, requestList);
-//        return ResponseEntity.ok().body(response);
-//    }
-//
-//    @Operation(summary = "이미지 다운로드", description = "해당 UUID를 가진 이미지 보여주기")
-//    @GetMapping(value = "/images")
-//    public ResponseEntity<?> downloadImage(@RequestParam("uuid") String fileName, @RequestParam("size") Integer size) throws Exception {
-//        byte[] imageData = diaryService.downloadImage(fileName, size);
-//
-//        if (imageData.length == 0)
-//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-//                    .body("fail");
-//        else
-//            return ResponseEntity.status(HttpStatus.OK)
-//                    .contentType(MediaType.valueOf("image/png"))
-//                    .body(imageData);
-//    }
-//
-//    @Operation(summary = "이미지 해당 달 조회", description = "현재 달에 해당하는 이미지 List 보여주기")
-//    @GetMapping(value = "/imageMonth")
-//    public ResponseEntity<?> getImageListForMonth() throws IOException {
-//        List<Map<Integer, DiaryResponse>> diaryMap = diaryService.getImageListByMonth();
-//        return ResponseEntity.ok().body(diaryMap);
-//    }
-//
-//    @Operation(summary = "해당 주 감정 점수 조회", description = "현재 주에 해당하는 감정 점수 보여주기")
-//    @GetMapping(value = "/scoreWeek")
-//    public ResponseEntity<?> getScoreListForWeek() throws IOException {
-//        List<Map<Integer, Integer>> diaryMap = diaryService.getScoreListForWeek();
-//        return ResponseEntity.ok().body(diaryMap);
-//    }
+    private final DiaryService diaryService;
+
+    @Operation(summary = "일기 작성", description = "작성 후 reponse로 그림 4개 return")
+    @PostMapping("")
+    public ResponseDto<DiaryWriteResponse> createDiary(HttpServletRequest servletRequest, @RequestBody DiaryWriteRequest request) throws IOException {
+        return ResponseDto.ok(diaryService.create(request, (Long)servletRequest.getAttribute("USER_ID")));
+    }
+////
+////    @Operation(summary = "일기 상세 조회", description = "id로 일기 상세 조회")
+////    @GetMapping(value = "/{id}")
+////    public ResponseEntity<DiaryResponse> getOneDiary(@PathVariable Long id) {
+////        DiaryResponse response = diaryService.getOneDiary(id);
+////        return ResponseEntity.ok().body(response);
+////    }
+////
+////    @Operation(summary = "이미지 선택", description = "4개의 이미지 중 사용자가 선택한 이미지만 남기기")
+////    @PutMapping(value = "/{id}/images")
+////    public ResponseEntity<DiaryResponse> chooseImage(@PathVariable Long id, @RequestBody List<ImageChooseRequest> requestList) throws IOException {
+////        DiaryResponse response = diaryService.chooseImage(id, requestList);
+////        return ResponseEntity.ok().body(response);
+////    }
+////
+////    @Operation(summary = "이미지 다운로드", description = "해당 UUID를 가진 이미지 보여주기")
+////    @GetMapping(value = "/images")
+////    public ResponseEntity<?> downloadImage(@RequestParam("uuid") String fileName, @RequestParam("size") Integer size) throws Exception {
+////        byte[] imageData = diaryService.downloadImage(fileName, size);
+////
+////        if (imageData.length == 0)
+////            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+////                    .body("fail");
+////        else
+////            return ResponseEntity.status(HttpStatus.OK)
+////                    .contentType(MediaType.valueOf("image/png"))
+////                    .body(imageData);
+////    }
+////
+////    @Operation(summary = "이미지 해당 달 조회", description = "현재 달에 해당하는 이미지 List 보여주기")
+////    @GetMapping(value = "/imageMonth")
+////    public ResponseEntity<?> getImageListForMonth() throws IOException {
+////        List<Map<Integer, DiaryResponse>> diaryMap = diaryService.getImageListByMonth();
+////        return ResponseEntity.ok().body(diaryMap);
+////    }
+////
+////    @Operation(summary = "해당 주 감정 점수 조회", description = "현재 주에 해당하는 감정 점수 보여주기")
+////    @GetMapping(value = "/scoreWeek")
+////    public ResponseEntity<?> getScoreListForWeek() throws IOException {
+////        List<Map<Integer, Integer>> diaryMap = diaryService.getScoreListForWeek();
+////        return ResponseEntity.ok().body(diaryMap);
+////    }
 }

--- a/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
+++ b/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
@@ -3,6 +3,7 @@ package com.grimpan.emodiary.controller;
 import com.grimpan.emodiary.dto.request.DiaryWriteRequest;
 import com.grimpan.emodiary.dto.response.DiaryResponse;
 import com.grimpan.emodiary.dto.response.DiaryWriteResponse;
+import com.grimpan.emodiary.dto.response.EmotionResponse;
 import com.grimpan.emodiary.dto.response.ResponseDto;
 import com.grimpan.emodiary.service.DiaryService;
 import io.swagger.annotations.Api;
@@ -41,6 +42,12 @@ public class DiaryController {
         List<Map.Entry<String, String>> diaryMap = diaryService.getImageListByDateRange(startDate, endDate, (Long)servletRequest.getAttribute("USER_ID"));
         return ResponseDto.ok(diaryMap);
     }
+
+    @Operation(summary = "월 감정 정보 조회", description = "해당 월의 일별 감정점수와 감정분포 조회")
+    @GetMapping(value = "/emotionInfo/monthly")
+    public ResponseDto<EmotionResponse> getEmotionInfotForMonthly(@RequestParam("date") String date,HttpServletRequest servletRequest) {
+        return ResponseDto.ok(diaryService.getEmotionInfoForMonthly(date,(Long)servletRequest.getAttribute("USER_ID")));
+    }
 ////
 ////    @Operation(summary = "이미지 선택", description = "4개의 이미지 중 사용자가 선택한 이미지만 남기기")
 ////    @PutMapping(value = "/{id}/images")
@@ -64,10 +71,5 @@ public class DiaryController {
 ////    }
 ////
 ////
-////    @Operation(summary = "해당 주 감정 점수 조회", description = "현재 주에 해당하는 감정 점수 보여주기")
-////    @GetMapping(value = "/scoreWeek")
-////    public ResponseEntity<?> getScoreListForWeek() throws IOException {
-////        List<Map<Integer, Integer>> diaryMap = diaryService.getScoreListForWeek();
-////        return ResponseEntity.ok().body(diaryMap);
-////    }
+
 }

--- a/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
+++ b/src/main/java/com/grimpan/emodiary/controller/DiaryController.java
@@ -38,7 +38,7 @@ public class DiaryController {
     @Operation(summary = "월단위 일기 조회", description = "구간에 해당하는 이미지 List 보여주기")
     @GetMapping(value = "/monthly")
     public ResponseDto<?> getImageListForMonth(HttpServletRequest servletRequest, @RequestParam("startDate") String startDate, @RequestParam("endDate") String endDate){
-        List<Map<String, String>> diaryMap = diaryService.getImageListByDateRange(startDate, endDate, (Long)servletRequest.getAttribute("USER_ID"));
+        List<Map.Entry<String, String>> diaryMap = diaryService.getImageListByDateRange(startDate, endDate, (Long)servletRequest.getAttribute("USER_ID"));
         return ResponseDto.ok(diaryMap);
     }
 ////

--- a/src/main/java/com/grimpan/emodiary/dto/request/DiaryWriteRequest.java
+++ b/src/main/java/com/grimpan/emodiary/dto/request/DiaryWriteRequest.java
@@ -9,5 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DiaryWriteRequest {
     private String title;
+
+    //추후 글자수 제한 추가
     private String content;
 }

--- a/src/main/java/com/grimpan/emodiary/dto/response/DiaryResponse.java
+++ b/src/main/java/com/grimpan/emodiary/dto/response/DiaryResponse.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class DiaryResponse {
     private Long id;
     private String title;
-    private String urlPath;
+    private String imgUrl;
     private String content;
 
     public static DiaryResponse of(Diary diary){

--- a/src/main/java/com/grimpan/emodiary/dto/response/EmotionResponse.java
+++ b/src/main/java/com/grimpan/emodiary/dto/response/EmotionResponse.java
@@ -1,0 +1,16 @@
+package com.grimpan.emodiary.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class EmotionResponse {
+    private String userName;
+    private List<Integer> emotionScore;
+    private List<Double> emotionDistribution;
+}

--- a/src/main/java/com/grimpan/emodiary/repository/DiaryRepository.java
+++ b/src/main/java/com/grimpan/emodiary/repository/DiaryRepository.java
@@ -14,6 +14,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 //    @Query(value = "select d from Diary d where d.id = :id")
 //    Optional<Diary> findForSetImage(@Param("id") Long diaryId);
 //
-//    @Query(value = "select d from Diary d where d.createdDate between :startDay and :endDay")
-//    List<Diary> findForMonthList(@Param("startDay") Timestamp startDay, @Param("endDay") Timestamp endDay);
+    @Query(value = "select d from Diary d where d.user.id = :userId and d.createdAt between to_timestamp(:startDay, 'YYYY-MM-DD') and to_timestamp(:endDay, 'YYYY-MM-DD') +  0.99999" )
+    List<Diary> findByUserIdAndBetweenCreatedAt(@Param("startDay") String startDay, @Param("endDay") String endDay, @Param("userId") Long userId);
 }

--- a/src/main/java/com/grimpan/emodiary/repository/DiaryRepository.java
+++ b/src/main/java/com/grimpan/emodiary/repository/DiaryRepository.java
@@ -10,10 +10,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-//
+    //
 //    @Query(value = "select d from Diary d where d.id = :id")
 //    Optional<Diary> findForSetImage(@Param("id") Long diaryId);
 //
-    @Query(value = "select d from Diary d where d.user.id = :userId and d.createdAt between to_timestamp(:startDay, 'YYYY-MM-DD') and to_timestamp(:endDay, 'YYYY-MM-DD') +  0.99999" )
+    @Query(value = "select d from Diary d where d.user.id = :userId and d.createdAt between to_timestamp(:startDay, 'YYYY-MM-DD') and to_timestamp(:endDay, 'YYYY-MM-DD') +  0.99999")
     List<Diary> findByUserIdAndBetweenCreatedAt(@Param("startDay") String startDay, @Param("endDay") String endDay, @Param("userId") Long userId);
 }

--- a/src/main/java/com/grimpan/emodiary/service/DiaryService.java
+++ b/src/main/java/com/grimpan/emodiary/service/DiaryService.java
@@ -61,11 +61,14 @@ public class DiaryService {
     }
 
 
-//
-//    public DiaryResponse getOneDiary(Long id) {
-//        Diary diary = diaryRepository.findById(id).orElseThrow(() -> new DiaryException(ErrorCode.DIARY_NOT_FOUND));
-//        return DiaryResponse.of(diary);
-//    }
+    @Transactional(readOnly = true)
+    public DiaryResponse getOneDiary(Long id, Long userId) {
+        Diary diary = diaryRepository.findById(id).orElseThrow(() -> new DiaryException(ErrorCode.DIARY_NOT_FOUND));
+        if(!diary.getUser().getId().equals(userId)){
+            throw new CommonException(ErrorCode.ACCESS_DENIED_ERROR, "해당 일기 작성자가 아닙니다.");
+        }
+        return DiaryResponse.of(diary);
+    }
 //
 //    @Transactional
 //    public DiaryResponse chooseImage(Long id, List<ImageChooseRequest> requestList) {

--- a/src/main/java/com/grimpan/emodiary/service/DiaryService.java
+++ b/src/main/java/com/grimpan/emodiary/service/DiaryService.java
@@ -26,6 +26,7 @@ import java.sql.Timestamp;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
 
@@ -113,42 +114,22 @@ public class DiaryService {
 //        return baos.toByteArray();
 //    }
 //
-//    public List<Map<Integer, DiaryResponse>> getImageListByMonth() {
-//        LocalDate currentDate = LocalDate.now();
-//
-//        int year = currentDate.getYear();  // 현재 연도
-//        int month = currentDate.getMonthValue();  // 현재 월
-//
-//        YearMonth yearMonth = YearMonth.of(year, month);
-//        LocalDate firstDay = yearMonth.atDay(1);  // 시작 날짜
-//        LocalDate lastDay = yearMonth.atEndOfMonth();  // 마지막 날짜
-//
-//        Date startDate = java.sql.Date.valueOf(firstDay);
-//        Date endDate = java.sql.Date.valueOf(lastDay.plusDays(1));
-//
-//        List<Diary> diaryList = diaryRepository.findForMonthList(new Timestamp(startDate.getTime()),
-//                new Timestamp(endDate.getTime()));
-//
-//        List<Map<Integer, DiaryResponse>> responseList = new ArrayList<>();
-//        for (int i = 1; i <= lastDay.getDayOfMonth(); i++) {
-//            Map<Integer, DiaryResponse> map = new HashMap<>();
-//            map.put(i, null);
-//            responseList.add(map);
-//        }
-//
-//        for (Diary diary : diaryList) {
-//            Map<Integer, DiaryResponse> map = new HashMap<>();
-//            map.put(diary.getCreatedDate().toLocalDateTime().getDayOfMonth(),
-//                    DiaryResponse.builder()
-//                    .id(diary.getId())
-//                    .title(diary.getTitle())
-//                    .urlPath(urlPath + "diary/images?uuid=" + diary.getArtName())
-//                    .content(diary.getContent()).build());
-//            responseList.set(diary.getCreatedDate().toLocalDateTime().getDayOfMonth() - 1, map);
-//        }
-//
-//        return responseList;
-//    }
+
+    @Transactional
+    public List<Map<String, String>> getImageListByDateRange(String startDate, String endDate, Long userId) {
+        //구간 내 diary 추출
+        List<Diary> diaryList = diaryRepository.findByUserIdAndBetweenCreatedAt(startDate, endDate, userId);
+        // diary id에 해당하는 image추출
+        List<Map<String, String>> responses = new ArrayList<>();
+        for (Diary diary : diaryList) {
+            Map<String, String> imageMap = new HashMap<>();
+            String date = diary.getCreatedAt().toLocalDateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            // image base64로 리턴
+            String image = "";
+            imageMap.put(date, image);
+        }
+        return responses;
+    }
 //
 //    public List<Map<Integer, Integer>> getScoreListForWeek() {
 //        LocalDate currentDate = LocalDate.now();

--- a/src/main/java/com/grimpan/emodiary/unit/DiaryUnit.java
+++ b/src/main/java/com/grimpan/emodiary/unit/DiaryUnit.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.IOException;
 import java.util.*;
 
 @Slf4j
@@ -31,9 +32,24 @@ public class DiaryUnit {
     @Value("${karlo.key}")
     private String KARLO_KEY;
 
+    @Value("${spring.url.path}")
+    private String urlPath;
+
     private static final RestTemplate restTemplate = new RestTemplate();
     private static final HttpHeaders headers = new HttpHeaders();
     private static final JSONObject body = new JSONObject();
+
+    public List<String> createImgUrlList(String content) throws IOException {
+        String keywords = getTokenByDiary(content);
+        return ImageToUrl(getImgNameList(keywords));
+    }
+    public List<String> ImageToUrl(List<String> imgNameList) throws IOException {
+        List<String> imageResponses = new ArrayList<>();
+        for(String imgName : imgNameList){
+            imageResponses.add(urlPath + "diary/images?uuid=" + imgName);
+        }
+        return imageResponses;
+    }
 
     public String getTokenByDiary(String content) {
         headers.clear();
@@ -98,7 +114,7 @@ public class DiaryUnit {
         return imgNames;
     }
 
-    public Long getEmotionScore(String content) {
+    public int getEmotionScore(String content) {
         headers.clear();
         headers.add("Content-type","application/json; charset=utf-8");
         headers.add("Authorization", "Bearer "+ GPT_KEY);
@@ -124,8 +140,9 @@ public class DiaryUnit {
         );
 
         JsonArray choices = (JsonArray) JsonParser.parseString(Objects.requireNonNull(response.getBody())).getAsJsonObject().get("choices");
-        return (long) choices.get(0).getAsJsonObject().get("message").getAsJsonObject().get("content").getAsInt();
+        return (int) choices.get(0).getAsJsonObject().get("message").getAsJsonObject().get("content").getAsInt();
     }
+
 
     @Getter
     @Builder


### PR DESCRIPTION
- 일기 추가 api
    - response로 4개의 이미지 url
- 일기 조회 api
- 월단위 일기 이미지 읽기 api
   - 구간(startDate, endDate)로 조회
   - 해당 일자의 이미지만 리턴(일기 내용 등 포함 x)
   - 이미지는 Base64로 리턴
- 월단위 감정 읽기 api
  - Request의 연월에 해당하는 감정 점수 리스트와 감정 분포(%) 반환
  - `emotionScore` : index + 1 = 일자
    - Ex) index 0 = 1일, index 1 = 2일
  - emotionDistribution : 감정 분포
    - `감정 분포(Good(70점~100점), Soso(31점~69점), Bad(0점~30점))`